### PR TITLE
Automate MFA setup for M365 users

### DIFF
--- a/AzureMFA/README.md
+++ b/AzureMFA/README.md
@@ -10,3 +10,26 @@ Click the button below to deploy
 <a href="http://armviz.io/#/?load=https%3A%2F%2Fraw.githubusercontent.com%2FAzure%2Fazure-quickstart-templates%2Fmaster%2Factive-directory-new-domain%2Fazuredeploy.json" target="_blank">
     <img src="http://armviz.io/visualizebutton.png"/>
 </a>
+
+# Automate MFA Setup for M365 Users
+
+This repository includes a script `SetupMFA.ps1` to automate the setup of Multi-Factor Authentication (MFA) for users in an M365 tenant. The script assesses users without MFA, creates groups, and assigns users to groups that enforce MFA using a Conditional Access policy.
+
+## Prerequisites
+
+1. Install the Entra ID PowerShell module by following the instructions in this [guide](https://learn.microsoft.com/en-us/powershell/entra-powershell/installation).
+
+## Usage
+
+1. Open PowerShell and navigate to the `AzureMFA` directory.
+2. Run the `SetupMFA.ps1` script:
+
+```powershell
+.\SetupMFA.ps1
+```
+
+3. The script will:
+   - Assess users without MFA.
+   - Create groups for enforcing MFA.
+   - Assign users without MFA to the created groups.
+   - Create a Conditional Access policy to enforce MFA.

--- a/AzureMFA/SetupMFA.ps1
+++ b/AzureMFA/SetupMFA.ps1
@@ -1,0 +1,30 @@
+# PowerShell script to automate MFA setup for users in an M365 tenant
+
+# Import necessary modules
+Import-Module Microsoft.Graph.Identity.SignIns
+Import-Module Microsoft.Graph.Authentication
+
+# Authenticate to Entra ID
+Connect-MgGraph -Scopes "User.Read.All", "Group.ReadWrite.All", "Policy.ReadWrite.ConditionalAccess"
+
+# Assess users without MFA
+$usersWithoutMFA = Get-MgUser -Filter "strongAuthenticationDetail/any(a:a/method eq null)"
+
+# Create groups for enforcing MFA
+$groupName = "MFAEnforcedUsers"
+$group = New-MgGroup -DisplayName $groupName -MailEnabled $false -SecurityEnabled $true -MailNickname $groupName
+
+# Assign users without MFA to the created groups
+foreach ($user in $usersWithoutMFA) {
+    Add-MgGroupMember -GroupId $group.Id -DirectoryObjectId $user.Id
+}
+
+# Create Conditional Access policy to enforce MFA
+$policyName = "EnforceMFA"
+$policy = New-MgConditionalAccessPolicy -DisplayName $policyName -State "Enabled" -Conditions @{
+    Users = @{
+        IncludeGroups = @($group.Id)
+    }
+} -GrantControls @{
+    BuiltInControls = @("Mfa")
+}


### PR DESCRIPTION
Add a new script to automate MFA setup for M365 users.

* Add `AzureMFA/SetupMFA.ps1` to automate MFA setup for users in an M365 tenant using Entra ID PowerShell commands.
* Assess users without MFA, create groups for enforcing MFA, and assign users to the created groups.
* Create a Conditional Access policy to enforce MFA for the assigned groups.
* Update `AzureMFA/README.md` to include instructions on how to use the `SetupMFA.ps1` script for automating MFA setup.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/krob527/TestDrives/pull/1?shareId=da900e59-cfcb-4dfe-b309-c2f0dc30de9c).